### PR TITLE
JSON Schema support.

### DIFF
--- a/org.eclipse.bluesky/plugin.xml
+++ b/org.eclipse.bluesky/plugin.xml
@@ -103,7 +103,8 @@
       <server
             class="org.eclipse.bluesky.JSonLanguageServer"
             id="org.eclipse.bluesky.json"
-            label="JSon Language Server (VSCode)">
+            label="JSon Language Server (VSCode)"
+            serverInterface="org.eclipse.bluesky.JSonLanguageServerInterface" >
       </server>
       <contentTypeMapping
             contentType="org.eclipse.bluesky.json"

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/JSonLanguageServer.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/JSonLanguageServer.java
@@ -7,18 +7,27 @@
  *
  * Contributors:
  *  Michał Niewrzał (Rogue Wave Software Inc.) - initial implementation
+ *  Angelo Zerr <angelo.zerr@gmail.com> - JSON Schema support
  *******************************************************************************/
 package org.eclipse.bluesky;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 
@@ -26,13 +35,69 @@ public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 		List<String> commands = new ArrayList<>();
 		commands.add(InitializeLaunchConfigurations.getNodeJsLocation());
 		try {
-			URL url = FileLocator.toFileURL(getClass().getResource("/language-servers/node_modules/vscode-json-languageserver/out/jsonServerMain.js"));
+			URL url = FileLocator.toFileURL(getClass()
+					.getResource("/language-servers/node_modules/vscode-json-languageserver/out/jsonServerMain.js"));
 			commands.add(new java.io.File(url.getPath()).getAbsolutePath());
 			commands.add("--stdio");
 			setCommands(commands);
 			setWorkingDirectory(System.getProperty("user.dir"));
 		} catch (IOException e) {
-			Activator.getDefault().getLog().log(new Status(IStatus.ERROR, Activator.getDefault().getBundle().getSymbolicName(), e.getMessage(), e));
+			Activator.getDefault().getLog().log(
+					new Status(IStatus.ERROR, Activator.getDefault().getBundle().getSymbolicName(), e.getMessage(), e));
 		}
+	}
+
+	@Override
+	public void handleMessage(Message message, LanguageServer languageServer, URI rootUri) {
+		if (message instanceof ResponseMessage) {
+			ResponseMessage responseMessage = (ResponseMessage) message;
+			if (responseMessage.getResult() instanceof InitializeResult) {
+				// Send json/schemaAssociations notification to register JSON Schema on JSON
+				// Language server side.
+				JSonLanguageServerInterface server = (JSonLanguageServerInterface) languageServer;
+				Map<String, List<String>> schemaAssociations = getSchemaAssociations();
+				server.sendJSonchemaAssociations(schemaAssociations);
+			}
+		}
+	}
+
+	private Map<String, List<String>> getSchemaAssociations() {
+		// TODO: provide eclipse extension point to defines JSON Schema associations.
+		Map<String, List<String>> associations = new HashMap<>();
+		fillSchemaAssociationsForJavascript(associations);
+		fillSchemaAssociationsForTypeScript(associations);
+		fillSchemaAssociationsForOmnisharp(associations);
+		return associations;
+	}
+
+	/**
+	 * JSON Schema contributions for JavaScript
+	 * 
+	 * @param associations
+	 */
+	private void fillSchemaAssociationsForJavascript(Map<String, List<String>> associations) {
+		associations.put("package.json", Arrays.asList("http://json.schemastore.org/package"));
+		associations.put("/bower.json", Arrays.asList("http://json.schemastore.org/bower"));		
+		associations.put("/.bower.json", Arrays.asList("http://json.schemastore.org/bower"));
+		associations.put("/.bowerrc", Arrays.asList("http://json.schemastore.org/bowercc"));
+		associations.put("/jsconfig.json", Arrays.asList("http://json.schemastore.org/jsconfig"));		
+	}
+
+	/**
+	 * JSON Schema contributions for TypeScript
+	 * 
+	 * @param associations
+	 */
+	private void fillSchemaAssociationsForTypeScript(Map<String, List<String>> associations) {
+		associations.put("/tsconfig.*.json", Arrays.asList("http://json.schemastore.org/tsconfig"));
+	}
+	
+	/**
+	 * JSON Schema contributions for TypeScript
+	 * 
+	 * @param associations
+	 */
+	private void fillSchemaAssociationsForOmnisharp(Map<String, List<String>> associations) {
+		associations.put("/omnisharp.json", Arrays.asList("http://json.schemastore.org/omnisharp"));
 	}
 }

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/JSonLanguageServerInterface.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/JSonLanguageServerInterface.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+/**
+ * Extends {@link LanguageServer} to support custom notification with JSON
+ * language server:
+ * 
+ * <ul>
+ * <li>"json/schemaAssociations" to send a mapping between fileMatch (ex:
+ * package.json) and uri (http://json.schemastore.org/package)</li>
+ * </ul>
+ *
+ */
+public interface JSonLanguageServerInterface extends LanguageServer {
+
+	@JsonNotification("json/schemaAssociations")
+	/**
+	 * Send the JSON Schema associations waited by the VSCode JSON Language Server.
+	 * 
+	 * @param schemaAssociations
+	 * @see https://github.com/Microsoft/vscode/blob/master/extensions/json/server/src/jsonServerMain.ts#L29
+	 */
+	void sendJSonchemaAssociations(Map<String, List<String>> schemaAssociations);
+}


### PR DESCRIPTION
This PR add JSON support. It could be improved by providing an jsonSchemaContribution extension point to avoid hard coding the associations between filrPattern and schema to use.

Schema can be a file too. I think it should be good BlueSky hosts some JSON Schema when it is not possible to download the schema.

The JSON Schema contribution is another sample that bluesky plugin should be splitted in several plugins. Each plugin contribute to associations (javascript, typescript, etc).