### PR TITLE
Implement Color symbols for JSON and CSS editor. See

### DIFF
--- a/org.eclipse.bluesky/plugin.xml
+++ b/org.eclipse.bluesky/plugin.xml
@@ -73,7 +73,15 @@
             path="language-configurations/json/language-configuration.json">
       </languageConfiguration>
    </extension>
-      
+
+   <extension
+         point="org.eclipse.ui.genericeditor.reconcilers">
+      <reconciler
+            class="org.eclipse.bluesky.colors.ColorSymbolReconciler"
+            contentType="org.eclipse.bluesky.json">
+      </reconciler>
+   </extension>
+         
    <!-- CSS Language -->
       
    <extension
@@ -106,7 +114,8 @@
       <server
             class="org.eclipse.bluesky.css.CSSLanguageServer"
             id="org.eclipse.bluesky.css"
-            label="CSS/LESS/SCSS Language Server (VSCode)">
+            label="CSS/LESS/SCSS Language Server (VSCode)"
+            serverInterface="org.eclipse.bluesky.css.CSSLanguageServerInterface">
       </server>
       <contentTypeMapping
             contentType="org.eclipse.bluesky.css"
@@ -140,6 +149,14 @@
             contentTypeId="org.eclipse.bluesky.css"
             path="language-configurations/css/language-configuration.json">
       </languageConfiguration>
+   </extension>
+
+   <extension
+         point="org.eclipse.ui.genericeditor.reconcilers">
+      <reconciler
+            class="org.eclipse.bluesky.colors.ColorSymbolReconciler"
+            contentType="org.eclipse.bluesky.css">
+      </reconciler>
    </extension>
          
    <!-- HTML Language -->   

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorAnnotationPainter.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorAnnotationPainter.java
@@ -1,0 +1,112 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.eclipse.jface.text.IPainter;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.PaintManager;
+import org.eclipse.jface.text.TextViewer;
+import org.eclipse.jface.text.source.AnnotationPainter;
+import org.eclipse.jface.text.source.AnnotationPainter.IDrawingStrategy;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
+
+/**
+ * Utilities to register Color annotation type in the {@link AnnotationPainter}
+ * used in a {@link ITextViewer}.
+ *
+ */
+public class ColorAnnotationPainter {
+
+	private static final IDrawingStrategy COLOR_SYMBOL_STRATEGY = new ColorSymbolDrawingStrategy();
+	private static final Object COLOR = "color";
+	private static final Color DUMMY_COLOR = new Color(null, new RGB(0, 0, 0));
+
+	/**
+	 * Initialize Color annotation type in the {@link AnnotationPainter} used by the
+	 * given {@link ITextViewer}.
+	 * 
+	 * @param viewer
+	 * @return true if annotation painter was initialized and false otherwise.
+	 */
+	public static boolean initializeColorPainter(ITextViewer viewer) {
+		// Get the annotation painter used by the viewer.
+		AnnotationPainter painter = ColorAnnotationPainter.getAnnotationPainter(viewer);
+		if (painter != null) {
+			// Initialize the color annotation type
+			painter.addDrawingStrategy(COLOR, COLOR_SYMBOL_STRATEGY);
+			painter.addAnnotationType(ColorSymbolAnnotation.TYPE, COLOR);
+			// the painter needs a color for an annotation type
+			// we must set it with a dummy color even if we don't use it to draw the color
+			// symbol.
+			painter.setAnnotationTypeColor(ColorSymbolAnnotation.TYPE, DUMMY_COLOR);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Retrieve the annotation painter used by the given text viewer.
+	 * 
+	 * @param viewer
+	 * @return
+	 */
+	private static AnnotationPainter getAnnotationPainter(ITextViewer viewer) {
+		// Here reflection is used, because
+		// - it doesn't exists API public for get AnnotationPainter used by the viewer.
+		// - it doesn't exists extension point to register custom drawing strategy. See
+		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=51498
+		PaintManager paintManager = ColorAnnotationPainter.getFieldValue(viewer, "fPaintManager", TextViewer.class);
+		if (paintManager != null) {
+			List<IPainter> painters = ColorAnnotationPainter.getFieldValue(paintManager, "fPainters",
+					PaintManager.class);
+			if (painters != null) {
+				for (IPainter painter : painters) {
+					if (painter instanceof AnnotationPainter) {
+						return (AnnotationPainter) painter;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private static <T> T getFieldValue(Object object, String name, Class clazz) {
+		Field f = getDeclaredField(clazz, name);
+		if (f != null) {
+			try {
+				return (T) f.get(object);
+			} catch (Exception e) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	private static Field getDeclaredField(Class clazz, String name) {
+		if (clazz == null) {
+			return null;
+		}
+		try {
+			Field f = clazz.getDeclaredField(name);
+			f.setAccessible(true);
+			return f;
+		} catch (NoSuchFieldException e) {
+			return getDeclaredField(clazz.getSuperclass(), name);
+		} catch (SecurityException e) {
+			return null;
+		}
+	}
+
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorHelper.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorHelper.java
@@ -1,0 +1,274 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGBA;
+
+/**
+ * Utilities to parse CSS string color and get SWT {@link Color}.
+ *
+ */
+public class ColorHelper {
+
+	private static final Pattern RGB_PATTERN = Pattern.compile("rgb *\\( *([0-9]+), *([0-9]+), *([0-9]+) *\\)");
+	private static final Pattern RGBA_PATTERN = Pattern
+			.compile("rgba *\\( *([0-9]+), *([0-9]+), *([0-9]+), *([0-9]+) *\\)");
+
+	private static final Map<String, String> colorNamesMap = new HashMap<>();
+
+	static {
+		colorNamesMap.put("aliceblue", "#F0F8FF");
+		colorNamesMap.put("antiquewhite", "#FAEBD7");
+		colorNamesMap.put("aqua", "#00FFFF");
+		colorNamesMap.put("aquamarine", "#7FFFD4");
+		colorNamesMap.put("azure", "#F0FFFF");
+		colorNamesMap.put("beige", "#F5F5DC");
+		colorNamesMap.put("bisque", "#FFE4C4");
+		colorNamesMap.put("black", "#000000");
+		colorNamesMap.put("blanchedalmond", "#FFEBCD");
+		colorNamesMap.put("blue", "#0000FF");
+		colorNamesMap.put("blueviolet", "#8A2BE2");
+		colorNamesMap.put("brown", "#A52A2A");
+		colorNamesMap.put("burlywood", "#DEB887");
+		colorNamesMap.put("cadetblue", "#5F9EA0");
+		colorNamesMap.put("chartreuse", "#7FFF00");
+		colorNamesMap.put("chocolate", "#D2691E");
+		colorNamesMap.put("coral", "#FF7F50");
+		colorNamesMap.put("cornflowerblue", "#6495ED");
+		colorNamesMap.put("cornsilk", "#FFF8DC");
+		colorNamesMap.put("crimson", "#DC143C");
+		colorNamesMap.put("cyan", "#00FFFF");
+		colorNamesMap.put("darkblue", "#00008B");
+		colorNamesMap.put("darkcyan", "#008B8B");
+		colorNamesMap.put("darkgoldenrod", "#B8860B");
+		colorNamesMap.put("darkgray", "#A9A9A9");
+		colorNamesMap.put("darkgrey", "#A9A9A9");
+		colorNamesMap.put("darkgreen", "#006400");
+		colorNamesMap.put("darkkhaki", "#BDB76B");
+		colorNamesMap.put("darkmagenta", "#8B008B");
+		colorNamesMap.put("darkolivegreen", "#556B2F");
+		colorNamesMap.put("darkorange", "#FF8C00");
+		colorNamesMap.put("darkorchid", "#9932CC");
+		colorNamesMap.put("darkred", "#8B0000");
+		colorNamesMap.put("darksalmon", "#E9967A");
+		colorNamesMap.put("darkseagreen", "#8FBC8F");
+		colorNamesMap.put("darkslateblue", "#483D8B");
+		colorNamesMap.put("darkslategray", "#2F4F4F");
+		colorNamesMap.put("darkslategrey", "#2F4F4F");
+		colorNamesMap.put("darkturquoise", "#00CED1");
+		colorNamesMap.put("darkviolet", "#9400D3");
+		colorNamesMap.put("deeppink", "#FF1493");
+		colorNamesMap.put("deepskyblue", "#00BFFF");
+		colorNamesMap.put("dimgray", "#696969");
+		colorNamesMap.put("dimgrey", "#696969");
+		colorNamesMap.put("dodgerblue", "#1E90FF");
+		colorNamesMap.put("firebrick", "#B22222");
+		colorNamesMap.put("floralwhite", "#FFFAF0");
+		colorNamesMap.put("forestgreen", "#228B22");
+		colorNamesMap.put("fuchsia", "#FF00FF");
+		colorNamesMap.put("gainsboro", "#DCDCDC");
+		colorNamesMap.put("ghostwhite", "#F8F8FF");
+		colorNamesMap.put("gold", "#FFD700");
+		colorNamesMap.put("goldenrod", "#DAA520");
+		colorNamesMap.put("gray", "#808080");
+		colorNamesMap.put("grey", "#808080");
+		colorNamesMap.put("green", "#008000");
+		colorNamesMap.put("greenyellow", "#ADFF2F");
+		colorNamesMap.put("honeydew", "#F0FFF0");
+		colorNamesMap.put("hotpink", "#FF69B4");
+		colorNamesMap.put("indianred", "#CD5C5C");
+		colorNamesMap.put("indigo", "#4B0082");
+		colorNamesMap.put("ivory", "#FFFFF0");
+		colorNamesMap.put("khaki", "#F0E68C");
+		colorNamesMap.put("lavender", "#E6E6FA");
+		colorNamesMap.put("lavenderblush", "#FFF0F5");
+		colorNamesMap.put("lawngreen", "#7CFC00");
+		colorNamesMap.put("lemonchiffon", "#FFFACD");
+		colorNamesMap.put("lightblue", "#ADD8E6");
+		colorNamesMap.put("lightcoral", "#F08080");
+		colorNamesMap.put("lightcyan", "#E0FFFF");
+		colorNamesMap.put("lightgoldenrodyellow", "#FAFAD2");
+		colorNamesMap.put("lightgray", "#D3D3D3");
+		colorNamesMap.put("lightgrey", "#D3D3D3");
+		colorNamesMap.put("lightgreen", "#90EE90");
+		colorNamesMap.put("lightpink", "#FFB6C1");
+		colorNamesMap.put("lightsalmon", "#FFA07A");
+		colorNamesMap.put("lightseagreen", "#20B2AA");
+		colorNamesMap.put("lightskyblue", "#87CEFA");
+		colorNamesMap.put("lightslategray", "#778899");
+		colorNamesMap.put("lightslategrey", "#778899");
+		colorNamesMap.put("lightsteelblue", "#B0C4DE");
+		colorNamesMap.put("lightyellow", "#FFFFE0");
+		colorNamesMap.put("lime", "#00FF00");
+		colorNamesMap.put("limegreen", "#32CD32");
+		colorNamesMap.put("linen", "#FAF0E6");
+		colorNamesMap.put("magenta", "#FF00FF");
+		colorNamesMap.put("maroon", "#800000");
+		colorNamesMap.put("mediumaquamarine", "#66CDAA");
+		colorNamesMap.put("mediumblue", "#0000CD");
+		colorNamesMap.put("mediumorchid", "#BA55D3");
+		colorNamesMap.put("mediumpurple", "#9370D8");
+		colorNamesMap.put("mediumseagreen", "#3CB371");
+		colorNamesMap.put("mediumslateblue", "#7B68EE");
+		colorNamesMap.put("mediumspringgreen", "#00FA9A");
+		colorNamesMap.put("mediumturquoise", "#48D1CC");
+		colorNamesMap.put("mediumvioletred", "#C71585");
+		colorNamesMap.put("midnightblue", "#191970");
+		colorNamesMap.put("mintcream", "#F5FFFA");
+		colorNamesMap.put("mistyrose", "#FFE4E1");
+		colorNamesMap.put("moccasin", "#FFE4B5");
+		colorNamesMap.put("navajowhite", "#FFDEAD");
+		colorNamesMap.put("navy", "#000080");
+		colorNamesMap.put("oldlace", "#FDF5E6");
+		colorNamesMap.put("olive", "#808000");
+		colorNamesMap.put("olivedrab", "#6B8E23");
+		colorNamesMap.put("orange", "#FFA500");
+		colorNamesMap.put("orangered", "#FF4500");
+		colorNamesMap.put("orchid", "#DA70D6");
+		colorNamesMap.put("palegoldenrod", "#EEE8AA");
+		colorNamesMap.put("palegreen", "#98FB98");
+		colorNamesMap.put("paleturquoise", "#AFEEEE");
+		colorNamesMap.put("palevioletred", "#D87093");
+		colorNamesMap.put("papayawhip", "#FFEFD5");
+		colorNamesMap.put("peachpuff", "#FFDAB9");
+		colorNamesMap.put("peru", "#CD853F");
+		colorNamesMap.put("pink", "#FFC0CB");
+		colorNamesMap.put("plum", "#DDA0DD");
+		colorNamesMap.put("powderblue", "#B0E0E6");
+		colorNamesMap.put("purple", "#800080");
+		colorNamesMap.put("red", "#FF0000");
+		colorNamesMap.put("rosybrown", "#BC8F8F");
+		colorNamesMap.put("royalblue", "#4169E1");
+		colorNamesMap.put("saddlebrown", "#8B4513");
+		colorNamesMap.put("salmon", "#FA8072");
+		colorNamesMap.put("sandybrown", "#F4A460");
+		colorNamesMap.put("seagreen", "#2E8B57");
+		colorNamesMap.put("seashell", "#FFF5EE");
+		colorNamesMap.put("sienna", "#A0522D");
+		colorNamesMap.put("silver", "#C0C0C0");
+		colorNamesMap.put("skyblue", "#87CEEB");
+		colorNamesMap.put("slateblue", "#6A5ACD");
+		colorNamesMap.put("slategray", "#708090");
+		colorNamesMap.put("slategrey", "#708090");
+		colorNamesMap.put("snow", "#FFFAFA");
+		colorNamesMap.put("springgreen", "#00FF7F");
+		colorNamesMap.put("steelblue", "#4682B4");
+		colorNamesMap.put("tan", "#D2B48C");
+		colorNamesMap.put("teal", "#008080");
+		colorNamesMap.put("thistle", "#D8BFD8");
+		colorNamesMap.put("tomato", "#FF6347");
+		colorNamesMap.put("turquoise", "#40E0D0");
+		colorNamesMap.put("violet", "#EE82EE");
+		colorNamesMap.put("wheat", "#F5DEB3");
+		colorNamesMap.put("white", "#FFFFFF");
+		colorNamesMap.put("whitesmoke", "#F5F5F5");
+		colorNamesMap.put("yellow", "#FFFF00");
+		colorNamesMap.put("yellowgreen", "#9ACD32");
+	}
+
+	/**
+	 * Returns the {@link RGBA} from the given string value which can be formatted
+	 * with 3 means:
+	 * 
+	 * <ul>
+	 * <li>color name format: "red, "black", etc</li>
+	 * <li>hexa color format: "#FF0000", "#000000"</li>
+	 * <li>rgb format: rgb(255,255,255)</li>
+	 * </ul>
+	 * 
+	 * @param value
+	 * @param display
+	 * @return
+	 */
+	public static RGBA getRGBColor(String value) {
+		if (value.startsWith("#") && value.length() == 7) {
+			// Hexa format
+			return fromHexa(value);
+		} else {
+			// Color name
+			if (isColorName(value)) {
+				return fromColorName(value);
+			}
+			// rgb format
+			return fromRGB(value);
+		}
+	}
+
+	public static boolean isColorName(String value) {
+		String colorName = value.toLowerCase();
+		return colorNamesMap.containsKey(colorName);
+	}
+
+	/**
+	 * Returns the RGBA color from the given hexa value.
+	 * 
+	 * @param value
+	 * @return the RGBA color.
+	 */
+	private static RGBA fromHexa(String value) {
+		try {
+			int redValue = Integer.decode("0x" + value.substring(1, 3)).intValue();
+			int greenValue = Integer.decode("0x" + value.substring(3, 5)).intValue();
+			int blueValue = Integer.decode("0x" + value.substring(5)).intValue();
+			return new RGBA(redValue, greenValue, blueValue, 255);
+		} catch (Exception arg) {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the RGBA color from the given color name value.
+	 * 
+	 * @param value
+	 * @return the RGBA color.
+	 */
+	private static RGBA fromColorName(String value) {
+		String colorName = value.toLowerCase();
+		String hexa = colorNamesMap.get(colorName);
+		return getRGBColor(hexa);
+	}
+
+	/**
+	 * Returns the RGBA color from the given rgb format value.
+	 * 
+	 * @param value
+	 * @return the RGBA color.
+	 */
+	private static RGBA fromRGB(String input) {
+		Matcher m = RGB_PATTERN.matcher(input);
+		if (m.matches()) {
+			return new RGBA(Integer.valueOf(m.group(1)), Integer.valueOf(m.group(2)), Integer.valueOf(m.group(3)), 255);
+		} else {
+			m = RGBA_PATTERN.matcher(input);
+			if (m.matches()) {
+				return new RGBA(Integer.valueOf(m.group(1)), Integer.valueOf(m.group(2)), Integer.valueOf(m.group(3)),
+						Integer.valueOf(m.group(4)));
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Convert the given rgb to hexa color.
+	 * 
+	 * @param rgb
+	 * @return the hexa color from the given rgb.
+	 */
+	public static String toHexa(RGBA rgb) {
+		return String.format("#%02x%02x%02x", rgb.rgb.red, rgb.rgb.green, rgb.rgb.blue);
+	}
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolAnnotation.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolAnnotation.java
@@ -1,0 +1,91 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GlyphMetrics;
+import org.eclipse.swt.graphics.RGBA;
+
+/**
+ * Color symbol annotation.
+ *
+ */
+class ColorSymbolAnnotation extends Annotation {
+
+	/**
+	 * The type of color annotations.
+	 */
+	public static final String TYPE = "org.eclipse.bluesky.color"; //$NON-NLS-1$
+
+	/**
+	 * Color provider
+	 *
+	 */
+	public interface IColorProvider {
+
+		Color getColor(RGBA rgba);
+	}
+
+	/**
+	 * The rgb color information.
+	 */
+	private final RGBA rgba;
+
+	/**
+	 * The position of the annotation. This information is required since color
+	 * symbol takes place with {@link GlyphMetrics} which must be updated.
+	 * 
+	 * @see explanation at
+	 *      {@link ColorSymbolSupport#applyTextPresentation(org.eclipse.jface.text.TextPresentation)}
+	 */
+	private final Position position;
+
+	/**
+	 * The color provider.
+	 */
+	private final IColorProvider colorProvider;
+
+	public ColorSymbolAnnotation(RGBA rgba, Position position, IColorProvider colorProvider) {
+		super(TYPE, false, null);
+		this.rgba = rgba;
+		this.position = position;
+		this.colorProvider = colorProvider;
+	}
+
+	/**
+	 * Returns the rgb color information.
+	 * 
+	 * @return the rgb color information.
+	 */
+	public RGBA getRGBA() {
+		return rgba;
+	}
+
+	/**
+	 * Returns the position of the annotation.
+	 * 
+	 * @return the position of the annotation
+	 */
+	public Position getPosition() {
+		return position;
+	}
+
+	/**
+	 * Returns the SWT Color.
+	 * 
+	 * @return the SWT Color.
+	 */
+	public Color getColor() {
+		return colorProvider.getColor(getRGBA());
+	}
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolDrawingStrategy.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolDrawingStrategy.java
@@ -1,0 +1,72 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationPainter.IDrawingStrategy;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Rectangle;
+
+/**
+ * Color symbol drawing strategy to draw a colorized square.
+ *
+ */
+class ColorSymbolDrawingStrategy implements IDrawingStrategy {
+
+	@Override
+	public void draw(Annotation annotation, GC gc, StyledText textWidget, int offset, int length, Color color) {
+		if (gc != null) {
+			ColorSymbolAnnotation ann = (ColorSymbolAnnotation) annotation;
+			if (ann.isMarkedDeleted()) {
+				return;
+			}
+			FontMetrics fontMetrics = gc.getFontMetrics();
+
+			// Compute position and size of the color square
+			Rectangle bounds = textWidget.getTextBounds(offset, offset);
+			int x = bounds.x + fontMetrics.getLeading();
+			int y = bounds.y + fontMetrics.getDescent();
+			int size = fontMetrics.getHeight() - 2 * fontMetrics.getDescent();
+			Rectangle rect = new Rectangle(x, y, size, size);
+
+			// Fill square
+			gc.setBackground(ann.getColor());
+			gc.fillRectangle(rect);
+
+			// Draw square box
+			gc.setForeground(textWidget.getForeground());
+			gc.drawRectangle(rect);
+
+			// The square replaces the first character of the color by taking a place
+			// (COLOR_SQUARE_WITH) by using GlyphMetrics
+			// Here we need to redraw this first character because GlyphMetrics clip this
+			// color character.
+			String s = textWidget.getText(offset, offset);
+			StyleRange style = textWidget.getStyleRangeAtOffset(offset);
+			if (style != null) {
+				if (style.background != null) {
+					gc.setBackground(style.background);
+				}
+				if (style.foreground != null) {
+					gc.setForeground(style.foreground);
+				}
+			}
+			gc.drawString(s, bounds.x + bounds.width - gc.stringExtent(s).x, bounds.y, true);
+		} else {
+			textWidget.redrawRange(offset, length, true);
+		}
+	}
+
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolReconciler.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolReconciler.java
@@ -1,0 +1,100 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.reconciler.AbstractReconciler;
+import org.eclipse.jface.text.reconciler.DirtyRegion;
+import org.eclipse.jface.text.reconciler.IReconciler;
+import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServiceAccessor.LSPDocumentInfo;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * {@link IReconciler} which consumes language server to get color ranges and
+ * update viewer by drawing colorized square.
+ *
+ */
+public class ColorSymbolReconciler extends AbstractReconciler {
+
+	private CompletableFuture<List<Range>> promise;
+
+	private ColorSymbolSupport colorSupport;
+
+	@Override
+	public void install(ITextViewer viewer) {
+		super.install(viewer);
+		// Install color support
+		colorSupport = new ColorSymbolSupport();
+		colorSupport.install((ISourceViewer) viewer);
+	}
+
+	@Override
+	public void uninstall() {
+		super.uninstall();
+		colorSupport.uninstall();
+		cancel();
+	}
+
+	@Override
+	protected void initialProcess() {
+		process(null);
+	}
+
+	@Override
+	protected void process(DirtyRegion dirtyRegion) {
+		// FIXME: I don't know which capabilities I must test????
+		List<LSPDocumentInfo> infos = LanguageServiceAccessor.getLSPDocumentInfosFor(getDocument(),
+				capabilities -> true);
+		// FIXME: lsp4e should provide a public API: see
+		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=521925
+		if (infos.isEmpty()) {
+			return;
+		}
+		LSPDocumentInfo info = infos.get(0);
+		// Cancel last call of findDocumentColors
+		cancel();
+		IDocument document = info.getDocument();
+		// Search list of color range
+		promise = ((DocumentColorProvider) info.getLanguageClient()).findDocumentColors(info.getFileUri());
+		promise.thenAccept(ranges -> {
+			// then update the UI
+			colorSupport.colorize(ranges);
+		});
+	}
+
+	@Override
+	protected void reconcilerDocumentChanged(IDocument newDocument) {
+
+	}
+
+	/**
+	 * Cancel the last call of 'documentHighlight'.
+	 */
+	private void cancel() {
+		if (promise != null && !promise.isDone()) {
+			promise.cancel(true);
+			promise = null;
+		}
+	}
+
+	@Override
+	public IReconcilingStrategy getReconcilingStrategy(String contentType) {
+		return null;
+	}
+
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolSupport.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/ColorSymbolSupport.java
@@ -1,0 +1,339 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.eclipse.bluesky.colors.ColorSymbolAnnotation.IColorProvider;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ISynchronizable;
+import org.eclipse.jface.text.ITextPresentationListener;
+import org.eclipse.jface.text.ITextViewerExtension2;
+import org.eclipse.jface.text.ITextViewerExtension4;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationModelEvent;
+import org.eclipse.jface.text.source.AnnotationPainter;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.IAnnotationModelExtension;
+import org.eclipse.jface.text.source.IAnnotationModelExtension2;
+import org.eclipse.jface.text.source.IAnnotationModelListener;
+import org.eclipse.jface.text.source.IAnnotationModelListenerExtension;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GlyphMetrics;
+import org.eclipse.swt.graphics.RGBA;
+
+/**
+ * Color symbol support which draw in the viewer colorized squares be according
+ * a list of color range to update.
+ *
+ */
+public class ColorSymbolSupport implements IColorProvider, ITextPresentationListener, IAnnotationModelListener,
+		IAnnotationModelListenerExtension {
+
+	/**
+	 * Place taken by the drawn square.
+	 */
+	private static final int COLOR_SQUARE_WITH = 30;
+
+	/**
+	 * Viewer to update.
+	 */
+	private ISourceViewer viewer;
+
+	/**
+	 * Holds the current color symbol annotations.
+	 */
+	private List<Annotation> colorSymbolAnnotations = null;
+
+	/**
+	 * True when {@link AnnotationPainter} is initialized with annotation color type
+	 * and false otherwise.
+	 */
+	private boolean painterInitialized;
+
+	private Map<RGBA, Color> colorsMap;
+
+	/**
+	 * Install color support for the given viewer.o
+	 * 
+	 * @param viewer
+	 */
+	public void install(ISourceViewer viewer) {
+		this.viewer = viewer;
+		colorsMap = new HashMap<>();
+	}
+
+	/**
+	 * Uninstall color support.
+	 */
+	public void uninstall() {
+		if (viewer != null) {
+			((ITextViewerExtension4) viewer).removeTextPresentationListener(this);
+			IAnnotationModel annotationModel = viewer.getAnnotationModel();
+			annotationModel.removeAnnotationModelListener(this);
+		}
+		colorsMap.values().forEach(color -> color.dispose());
+		this.viewer = null;
+	}
+
+	/**
+	 * Update UI with the given list of color range.
+	 * 
+	 * @param ranges
+	 */
+	public void colorize(List<Range> ranges) {
+		initializePainter();
+		updateAnnotations(ranges);
+	}
+
+	/**
+	 * Initialize {@link AnnotationPainter} with annotation color type if needed.
+	 */
+	private void initializePainter() {
+		if (painterInitialized) {
+			return;
+		}
+		painterInitialized = ColorAnnotationPainter.initializeColorPainter(viewer);
+		if (painterInitialized) {
+			((ITextViewerExtension4) viewer).addTextPresentationListener(this);
+			IAnnotationModel annotationModel = viewer.getAnnotationModel();
+			annotationModel.addAnnotationModelListener(this);
+		}
+	}
+
+	/**
+	 * Update the UI annotations with the given list of Color range.
+	 *
+	 * @param highlights
+	 *            list of DocumentHighlight
+	 * @param annotationModel
+	 *            annotation model to update.
+	 */
+	private void updateAnnotations(List<? extends Range> ranges) {
+		IAnnotationModel annotationModel = viewer.getAnnotationModel();
+		IDocument document = viewer.getDocument();
+		Map<Annotation, Position> annotationsToAdd = new HashMap<>(ranges.size());
+		// Initialize annotations to delete with last annotations
+		List<Annotation> annotationsToRemove = colorSymbolAnnotations != null ? new ArrayList<>(colorSymbolAnnotations)
+				: Collections.emptyList();
+		List<Annotation> currentAnnotations = new ArrayList<>();
+		// Loop for color ranges
+		for (Range range : ranges) {
+			try {
+				int startOffset = LSPEclipseUtils.toOffset(range.getStart(), document);
+				int endOffset = LSPEclipseUtils.toOffset(range.getEnd(), document);
+				int length = endOffset - startOffset;
+				String text = document.get(startOffset, length);
+				RGBA rgba = ColorHelper.getRGBColor(text);
+				if (rgba != null) {
+					Position pos = new Position(startOffset, length);
+					// Try to find existing annotation
+					ColorSymbolAnnotation ann = findExistingAnnotation(pos, rgba);
+					if (ann == null) {
+						// The annotation doesn't exists, create it.
+						ann = new ColorSymbolAnnotation(rgba, pos, this);
+						annotationsToAdd.put(ann, pos);
+					} else {
+						// The annotation exists, remove it from the list to delete.
+						annotationsToRemove.remove(ann);
+					}
+					currentAnnotations.add(ann);
+				}
+			} catch (BadLocationException e) {
+			}
+		}
+
+		synchronized (getLockObject(annotationModel)) {
+			colorSymbolAnnotations = currentAnnotations;
+			if (annotationsToAdd.size() == 0 && annotationsToRemove.size() == 0) {
+				// None change, do nothing. Here the user could change position of color range
+				// (ex: user key press
+				// "Enter"), but we don't need to redraw the viewer because change of position
+				// is done by AnnotationPainter.
+				return;
+			}
+			if (annotationModel instanceof IAnnotationModelExtension) {
+				((IAnnotationModelExtension) annotationModel).replaceAnnotations(
+						annotationsToRemove.toArray(new Annotation[annotationsToRemove.size()]), annotationsToAdd);
+			} else {
+				removeColorSymbolAnnotations();
+				Iterator<Entry<Annotation, Position>> iter = annotationsToAdd.entrySet().iterator();
+				while (iter.hasNext()) {
+					Entry<Annotation, Position> mapEntry = iter.next();
+					annotationModel.addAnnotation(mapEntry.getKey(), mapEntry.getValue());
+				}
+			}
+
+			// Compute start, end offset range used to invalidate text presentation
+			// by using added and deleted annotations
+			List<Annotation> allAnnotations = new ArrayList<>(annotationsToAdd.keySet());
+			allAnnotations.addAll(annotationsToRemove);
+			Collections.sort(allAnnotations, (a1, a2) -> {
+				return ((ColorSymbolAnnotation) a1).getPosition().offset
+						- ((ColorSymbolAnnotation) a2).getPosition().offset;
+			});
+
+			Position first = ((ColorSymbolAnnotation) allAnnotations.get(0)).getPosition();
+			Position end = allAnnotations.size() > 1
+					? ((ColorSymbolAnnotation) allAnnotations.get(allAnnotations.size() - 1)).getPosition()
+					: null;
+			IRegion region = new Region(first.getOffset(), end == null ? first.getLength() > 0 ? first.getLength() : 1
+					: end.getOffset() + end.getLength() - first.getOffset());
+
+			// invalidate only changed
+			viewer.getTextWidget().getDisplay().asyncExec(() -> {
+				if (viewer instanceof ITextViewerExtension2)
+					((ITextViewerExtension2) viewer).invalidateTextPresentation(region.getOffset(), region.getLength());
+				else
+					viewer.invalidateTextPresentation();
+			});
+		}
+	}
+
+	/**
+	 * Returns existing color annotation with the given position and rgb color
+	 * information and null otherwise.
+	 * 
+	 * @param pos
+	 * @param rgba
+	 * @return
+	 */
+	private ColorSymbolAnnotation findExistingAnnotation(Position pos, RGBA rgba) {
+		if (colorSymbolAnnotations == null) {
+			return null;
+		}
+		for (Annotation annotation : colorSymbolAnnotations) {
+			ColorSymbolAnnotation ann = (ColorSymbolAnnotation) annotation;
+			if (ann.getPosition().offset == pos.offset && ann.getRGBA().equals(rgba)) {
+				return ann;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the lock object for the given annotation model.
+	 *
+	 * @param annotationModel
+	 *            the annotation model
+	 * @return the annotation model's lock object
+	 */
+	private Object getLockObject(IAnnotationModel annotationModel) {
+		if (annotationModel instanceof ISynchronizable) {
+			Object lock = ((ISynchronizable) annotationModel).getLockObject();
+			if (lock != null)
+				return lock;
+		}
+		return annotationModel;
+	}
+
+	void removeColorSymbolAnnotations() {
+
+		IAnnotationModel annotationModel = viewer.getAnnotationModel();
+		if (annotationModel == null || colorSymbolAnnotations == null)
+			return;
+
+		synchronized (getLockObject(annotationModel)) {
+			if (annotationModel instanceof IAnnotationModelExtension) {
+				((IAnnotationModelExtension) annotationModel).replaceAnnotations(
+						colorSymbolAnnotations.toArray(new Annotation[colorSymbolAnnotations.size()]), null);
+			} else {
+				for (Annotation fColorSymbolAnnotation : colorSymbolAnnotations)
+					annotationModel.removeAnnotation(fColorSymbolAnnotation);
+			}
+			colorSymbolAnnotations = null;
+		}
+	}
+
+	@Override
+	public void modelChanged(IAnnotationModel model) {
+		// Do nothing
+	}
+
+	@Override
+	public void modelChanged(AnnotationModelEvent event) {
+		Annotation[] removed = event.getRemovedAnnotations();
+		if (removed != null) {
+			for (Annotation annotation : removed) {
+				// Mark color symbol annotation as deleted
+				if (ColorSymbolAnnotation.TYPE.equals(annotation.getType())) {
+					((ColorSymbolAnnotation) annotation).markDeleted(true);
+				}
+			}
+		}
+	}
+
+	@Override
+	public Color getColor(RGBA rgba) {
+		Color color = colorsMap.get(rgba);
+		if (color != null) {
+			return color;
+		}
+		color = new Color(viewer.getTextWidget().getDisplay(), rgba);
+		colorsMap.put(rgba, color);
+		return color;
+	}
+
+	@Override
+	public void applyTextPresentation(TextPresentation textPresentation) {
+		// Color symbol annotation is drawn with a colorized square which takes place.
+		// SWT StyledText doesn't provide the capability to draw a square which takes
+		// place without modifying
+		// the StyledText content (by using \uFFFC).
+		// To fix this problem, we use the following idea:
+		// - set with of colorized square with GlyphMetrics in the start offset of color
+		// range
+		// - redraw the character replaced by GlyphMetrics
+		IAnnotationModel annotationModel = viewer.getAnnotationModel();
+		IRegion region = textPresentation.getExtent();
+		((IAnnotationModelExtension2) annotationModel)
+				.getAnnotationIterator(region.getOffset(), region.getLength(), true, true)
+				.forEachRemaining(annotation -> {
+					if (isIncluded(annotation)) {
+						// Annotation is a color symbol
+						ColorSymbolAnnotation ann = (ColorSymbolAnnotation) annotation;
+						// Get the position of the annotation.
+						// We cannot use "annotationModel.getPosition(annotation);" because when
+						// annotation is removed, the position returned by annotation model is null.
+						// To fix that, position is stored inside ColorSymbolAnnotation
+						Position position = ann.getPosition();
+						if (position != null) {
+							StyleRange s = new StyleRange();
+							s.start = position.getOffset();
+							s.length = 1;
+							// if annotation is removed, update metrics to null otherwise, set a
+							// GlyphMetrics with a width
+							s.metrics = ann.isMarkedDeleted() ? null : new GlyphMetrics(0, 0, COLOR_SQUARE_WITH);
+							textPresentation.mergeStyleRange(s);
+						}
+					}
+				});
+	}
+
+	private static boolean isIncluded(Annotation annotation) {
+		return (annotation instanceof ColorSymbolAnnotation);
+	}
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/DocumentColorProvider.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/colors/DocumentColorProvider.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.colors;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Language server API to collect color symbols for a given text document.
+ *
+ */
+public interface DocumentColorProvider {
+
+	/**
+	 * The request is sent from the client to the server to collect ranges which
+	 * defined color symbols for the given text document.
+	 * 
+	 * @param uri
+	 *            text document URI.
+	 * @return list of ranges which defined color symbols for the given text
+	 *         document.
+	 */
+	CompletableFuture<List<Range>> findDocumentColors(URI uri);
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/css/CSSLanguageServerInterface.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/css/CSSLanguageServerInterface.java
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.bluesky.css;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.bluesky.colors.DocumentColorProvider;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+public interface CSSLanguageServerInterface extends LanguageServer, DocumentColorProvider {
+
+	@Override
+	@JsonRequest("css/colorSymbols")
+	CompletableFuture<List<Range>> findDocumentColors(URI uri);
+
+}

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/json/JSonLanguageServerInterface.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/json/JSonLanguageServerInterface.java
@@ -10,10 +10,15 @@
  */
 package org.eclipse.bluesky.json;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.bluesky.colors.DocumentColorProvider;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 /**
@@ -23,17 +28,23 @@ import org.eclipse.lsp4j.services.LanguageServer;
  * <ul>
  * <li>"json/schemaAssociations" to send a mapping between fileMatch (ex:
  * package.json) and uri (http://json.schemastore.org/package)</li>
+ * <li>"json/colorSymbols" to request color symbols for a given document.</li>
  * </ul>
  *
  */
-public interface JSonLanguageServerInterface extends LanguageServer {
+public interface JSonLanguageServerInterface extends LanguageServer, DocumentColorProvider {
 
-	@JsonNotification("json/schemaAssociations")
 	/**
 	 * Send the JSON Schema associations waited by the VSCode JSON Language Server.
 	 * 
 	 * @param schemaAssociations
 	 * @see https://github.com/Microsoft/vscode/blob/master/extensions/json/server/src/jsonServerMain.ts#L29
 	 */
+	@JsonNotification("json/schemaAssociations")
 	void sendJSonchemaAssociations(Map<String, List<String>> schemaAssociations);
+
+	@Override
+	@JsonRequest("json/colorSymbols")
+	CompletableFuture<List<Range>> findDocumentColors(URI uri);
+
 }


### PR DESCRIPTION
This PR provides the capability to draw a square with the well color inside the text editor for CSS and JSON language server (see https://github.com/mickaelistria/eclipse-bluesky/issues/30)

Here a little demo:

![csscolordemo](https://user-images.githubusercontent.com/1932211/30153820-198a246c-93b8-11e7-8612-65aefb16f7f1.gif)

Here some technical information:

 * when editor is opened or content changed, a reconciler consumes colo, rSymbols command from CSS, JSON language server.
 * colorSymbols  returns a list of range where color is defined (color name, rgb, rgba).
 * a ColorSupport transform those range to SWT Color and compute standard Eclipse Annotation (I'm using AnnotaionPainter for that)
 * the square which is drawn takes place. To do that, I'm using the following idea:
   * update SWT StyleRange with GlyphMetrics in the ColorSupport#applyTextPresentation of the first character which defines the color.
   * redraw this first character because the use of GlyphMetrics clip this character.
   * to call ColorSupport#applyTextPresentation after color annotations are updated, invalidateTextPresentation must be called.

To draw color annotation, I'm using existing AnnotationPainter and implement my own AnnotaionPainter#IDrawingStrategy. This AnnotaionPainter is initialized inside the SourceViewerSupport and store inside the TextViewer. I'm using reflection to get it and register my own IDrawingStrategy.
