### PR TITLE
Parent of LESS, SCSS/SASS content type should be CSS

### DIFF
--- a/org.eclipse.bluesky/plugin.xml
+++ b/org.eclipse.bluesky/plugin.xml
@@ -87,14 +87,14 @@
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
-            base-type="org.eclipse.bluesky.parent"
+            base-type="org.eclipse.bluesky.css"
             file-extensions="less"
             id="org.eclipse.bluesky.less"
             name="LESS"
             priority="normal">
       </content-type>
       <content-type
-            base-type="org.eclipse.bluesky.parent"
+            base-type="org.eclipse.bluesky.css"
             file-extensions="scss,sass"
             id="org.eclipse.bluesky.scss"
             name="SCSS/SASS"


### PR DESCRIPTION
LESS, SCSS/SASS content types should extends CSS content type. With this change LESS, SCSS/SASS editor could benefit with color feature once LESS, SCSS/SASS editors will be fixed by https://github.com/mickaelistria/eclipse-bluesky/pull/46