### PR TITLE
Update target platform to photon

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?><target name="bluesky" sequenceNumber="10">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<repository location="http://download.eclipse.org/eclipse/updates/4.8milestones/"/>
+	<repository location="http://download.eclipse.org/eclipse/updates/4.8/"/>
 	<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 	<unit id="org.hamcrest" version="0.0.0"/>
 	<unit id="org.junit" version="0.0.0"/>


### PR DESCRIPTION
It was looking to `http://download.eclipse.org/eclipse/updates/4.8milestone` but that repository does not exist because Photon was released.

The new repository is at `http://download.eclipse.org/eclipse/updates/4.8/`