### PR TITLE
update language server

### DIFF
--- a/org.eclipse.bluesky/language-servers/package.json
+++ b/org.eclipse.bluesky/language-servers/package.json
@@ -7,9 +7,9 @@
   "author": "Eclipse BlueSky",
   "license": "EPL",
   "dependencies": {
-  	"vscode-html-languageserver": "../target/vscode/VSCode-linux-x64/resources/app/extensions/html/server",
-  	"vscode-json-languageserver": "../target/vscode/VSCode-linux-x64/resources/app/extensions/json/server",
-  	"vscode-css-languageserver": "../target/vscode/VSCode-linux-x64/resources/app/extensions/css/server",
-  	"javascript-typescript-langserver": "^2.8.0"
+    "vscode-html-languageserver": "../target/vscode/VSCode-linux-x64/resources/app/extensions/html-language-features/server",
+    "vscode-json-languageserver": "../target/vscode/VSCode-linux-x64/resources/app/extensions/json-language-features/server",
+    "vscode-css-languageserver": "../target/vscode/VSCode-linux-x64/resources/app/extensions/css-language-features/server",
+    "javascript-typescript-langserver": "2.10.0"
   }
 }

--- a/org.eclipse.bluesky/pom.xml
+++ b/org.eclipse.bluesky/pom.xml
@@ -33,7 +33,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://az764295.vo.msecnd.net/stable/79b44aa704ce542d8ca4a3cc44cfca566e7720f1/code-stable-code_1.21.1-1521038896_amd64.tar.gz</url>
+							<url>https://az764295.vo.msecnd.net/stable/0f080e5267e829de46638128001aeb7ca2d6d50e/code-stable-code_1.25.0-1530796411_amd64.tar.gz</url>
 							<unpack>true</unpack>
 							<outputDirectory>${project.build.directory}/vscode</outputDirectory>
 						</configuration>

--- a/org.eclipse.bluesky/src/org/eclipse/bluesky/json/JSonLanguageServer.java
+++ b/org.eclipse.bluesky/src/org/eclipse/bluesky/json/JSonLanguageServer.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *  Michal‚ Niewrzal‚ (Rogue Wave Software Inc.) - initial implementation
+ *  Michalï¿½ Niewrzalï¿½ (Rogue Wave Software Inc.) - initial implementation
  *  Angelo Zerr <angelo.zerr@gmail.com> - JSON Schema support
  *******************************************************************************/
 package org.eclipse.bluesky.json;
@@ -81,7 +81,7 @@ public class JSonLanguageServer extends ProcessStreamConnectionProvider {
 		associations.put("package.json", Arrays.asList("http://json.schemastore.org/package"));
 		associations.put("/bower.json", Arrays.asList("http://json.schemastore.org/bower"));
 		associations.put("/.bower.json", Arrays.asList("http://json.schemastore.org/bower"));
-		associations.put("/.bowerrc", Arrays.asList("http://json.schemastore.org/bowercc"));
+		associations.put("/.bowerrc", Arrays.asList("http://json.schemastore.org/bowerrc"));
 		associations.put("/jsconfig.json", Arrays.asList("http://json.schemastore.org/jsconfig"));
 	}
 


### PR DESCRIPTION
Hello @mickaelistria 
I updated the language servers from VS Code. I get some errors during the use of the html language server. 

For example: 

```
<html>
<head>
<style>|

</head>
<body>
</body>
</html>
```

When I invoke the completion where the | is present (| represent the caret) I get the following error. 

```
!ENTRY org.eclipse.lsp4e 4 0 2018-07-11 21:51:59.989
!MESSAGE org.eclipse.lsp4j.jsonrpc.MessageIssueException: Message could not be parsed.
!STACK 0
java.util.concurrent.ExecutionException: org.eclipse.lsp4j.jsonrpc.MessageIssueException: Message could not be parsed.
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1895)
	at org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor.lambda$2(LSContentAssistProcessor.java:128)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1380)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:291)
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:401)
	at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:734)
	at java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:160)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:583)
	at org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor.computeCompletionProposals(LSContentAssistProcessor.java:125)
	at org.eclipse.jface.text.contentassist.AsyncCompletionProposalPopup.lambda$8(AsyncCompletionProposalPopup.java:341)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1582)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: org.eclipse.lsp4j.jsonrpc.MessageIssueException: Message could not be parsed.
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleResponseIssues(RemoteEndpoint.java:354)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handle(RemoteEndpoint.java:313)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:192)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:90)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:95)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

I don't know what is the message send between the client and the server. 