### PR TITLE
Ensure that the update site contains org.apache.commons.lang3

### DIFF
--- a/repository/category.xml
+++ b/repository/category.xml
@@ -72,6 +72,9 @@
    <bundle id="org.apache.commons.commons-compress" version="0.0.0">
       <category name="Dependencies"/>
    </bundle>
+   <bundle id="org.apache.commons.lang3" version="0.0.0">
+      <category name="Dependencies"/>
+   </bundle>
    <bundle id="org.snakeyaml.engine">
       <category name="Dependencies"/>
    </bundle>


### PR DESCRIPTION
This is required by org.eclipse.wildwebdeveloper.embedder.node because it's required by
org.apache.commons.compress.archivers.tar.TarArchiveEntry.normalizeFileName(String, boolean) for org.apache.commons.commons-compress version 2.26.2.