### PR TITLE
Fix Windows UNC Path issues

### DIFF
--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/AbstractDebugAdapterLaunchShortcut.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/AbstractDebugAdapterLaunchShortcut.java
@@ -6,7 +6,7 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *   Pierre-Yves B. - Issue #309 Launch called from the wrong thread
  *******************************************************************************/
@@ -43,6 +43,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.wildwebdeveloper.util.FileUtils;
 
 public abstract class AbstractDebugAdapterLaunchShortcut implements ILaunchShortcut2 {
 
@@ -156,7 +157,7 @@ public abstract class AbstractDebugAdapterLaunchShortcut implements ILaunchShort
 						DebugUITools.launch(configuration, mode);
 					} else {
 						if (DebugUIPlugin.openLaunchConfigurationEditDialog(Display.getCurrent().getActiveShell(), configuration, DebugUITools.getLaunchGroup(configuration, mode).getIdentifier(), null, true) == IDialogConstants.OK_ID) {
-							DebugUITools.launch(configuration, mode);	
+							DebugUITools.launch(configuration, mode);
 						}
 					}
 				});
@@ -202,7 +203,7 @@ public abstract class AbstractDebugAdapterLaunchShortcut implements ILaunchShort
 		String configName = launchManager.generateLaunchConfigurationName(file.getAbsolutePath());
 		ILaunchConfigurationWorkingCopy wc = configType.newInstance(null, configName);
 		wc.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, file.getParentFile().getAbsolutePath());
-		wc.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(file.toURI()));
+		wc.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(FileUtils.toUri(file)));
 		configureLaunchConfiguration(file, wc);
 		return wc;
 	}
@@ -210,7 +211,7 @@ public abstract class AbstractDebugAdapterLaunchShortcut implements ILaunchShort
 	/**
 	 * Takes a working copy of a launch configuration and sets the default
 	 * attributes according to provided file
-	 * 
+	 *
 	 * @param file
 	 * @param wc
 	 */

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/AbstractRunHTMLDebugTab.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/AbstractRunHTMLDebugTab.java
@@ -56,9 +56,10 @@ import org.eclipse.ui.views.navigator.ResourceComparator;
 import org.eclipse.wildwebdeveloper.Activator;
 import org.eclipse.wildwebdeveloper.debug.chrome.ChromeRunDAPDebugDelegate;
 import org.eclipse.wildwebdeveloper.debug.chrome.ChromeRunDebugLaunchShortcut;
+import org.eclipse.wildwebdeveloper.util.FileUtils;
 
 public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfigurationTab {
-	
+
 	private Text programPathText;
 	private Text argumentsText;
 	private Text workingDirectoryText;
@@ -82,8 +83,8 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 	public void createControl(Composite parent) {
 		resComposite = new Composite(parent, SWT.NONE);
 		resComposite.setLayout(new GridLayout(4, false));
-		
-		fileRadio = createRadioButton(resComposite, Messages.FirefoxDebugTab_File); 
+
+		fileRadio = createRadioButton(resComposite, Messages.FirefoxDebugTab_File);
 		fileRadio.setToolTipText(Messages.AbstractRunHTMLDebugTab_fileRadioToolTip);
 		fileRadio.setLayoutData(new GridData(SWT.DEFAULT, SWT.DEFAULT, false, false));
 		fileRadio.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
@@ -96,7 +97,7 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 			validateProgramPathAndURL();
 			updateLaunchConfigurationDialog();
 		}));
-		
+
 		this.programPathText = new Text(resComposite, SWT.BORDER);
 		this.programPathText.setLayoutData(new GridData(SWT.FILL, SWT.DEFAULT, true, false, 2, 1));
 		fileDecoration = new ControlDecoration(programPathText, SWT.TOP | SWT.LEFT);
@@ -118,7 +119,7 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 				programPathText.setText(path);
 			}
 		}));
-		
+
 		urlRadio = createRadioButton(resComposite, "URL: ");
 		urlRadio.setToolTipText(Messages.RunFirefoxDebugTab_URL_Note);
 		urlRadio.setLayoutData(new GridData(SWT.DEFAULT, SWT.DEFAULT, false, false));
@@ -142,7 +143,7 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 			validateProgramPathAndURL();
 			updateLaunchConfigurationDialog();
 		});
-		
+
 		new Label(resComposite, SWT.NONE).setText(Messages.AbstractRunHTMLDebugTab_webRoot_folder);
 		webRootText = new Text(resComposite, SWT.BORDER);
 		webRootText.setLayoutData(new GridData(SWT.FILL, SWT.DEFAULT, true, false));
@@ -232,7 +233,7 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 
 	private void validateProgramPathAndURL() {
 		setDirty(true);
-		
+
 		setErrorMessage(null);
 		fileDecoration.hide();
 		urlDecoration.hide();
@@ -252,23 +253,23 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 			} catch (CoreException ex) {
 				errorMessage = ex.getMessage();
 			}
-			
+
 			if (errorMessage != null) {
 				setErrorMessage(errorMessage);
 				fileDecoration.setDescriptionText(errorMessage);
 				fileDecoration.show();
 			}
-			
+
 		} else if (urlRadio.getSelection()) {
 			try {
 				new URL(urlText.getText());
 			} catch (MalformedURLException ex) {
 				errorMessage = MessageFormat.format(
-						Messages.RunProgramTab_error_malformedUR, 
+						Messages.RunProgramTab_error_malformedUR,
 						ex.getMessage());
 				urlDecoration.setDescriptionText(errorMessage);
 				urlDecoration.show();
-			}				
+			}
 			boolean showWebRootDecoration = false;
 			if(webRootText.getText().isBlank()) {
 				errorMessage = Messages.AbstractRunHTMLDebugTab_cannot_debug_without_webroot;
@@ -338,9 +339,9 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 				webRootProjectSelectButton.setEnabled(true);
 				webRootFilesystemSelectButton.setEnabled(true);
 			}
-			
+
 			validateProgramPathAndURL();
-			
+
 		} catch (CoreException e) {
 			ILog.get().log(e.getStatus());
 		}
@@ -357,7 +358,7 @@ public abstract class AbstractRunHTMLDebugTab extends AbstractLaunchConfiguratio
 		configuration.setAttribute(AbstractHTMLDebugDelegate.ARGUMENTS, this.argumentsText.getText());
 		String workingDirectory = this.workingDirectoryText.getText();
 		configuration.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, workingDirectory);
-		configuration.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(new File(programPath).toURI()));
+		configuration.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(FileUtils.toUri(programPath)));
 	}
 
 	@Override

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/node/RunProgramTab.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/node/RunProgramTab.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.wildwebdeveloper.debug.LaunchConstants;
 import org.eclipse.wildwebdeveloper.debug.Messages;
+import org.eclipse.wildwebdeveloper.util.FileUtils;
 
 public class RunProgramTab extends AbstractLaunchConfigurationTab {
 
@@ -127,7 +128,7 @@ public class RunProgramTab extends AbstractLaunchConfigurationTab {
 		configuration.setAttribute(LaunchConstants.PROGRAM, programPath);
 		configuration.setAttribute(NodeRunDAPDebugDelegate.ARGUMENTS, this.argumentsText.getText());
 		configuration.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, this.workingDirectoryText.getText());
-		configuration.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(new File(programPath).toURI()));
+		configuration.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(FileUtils.toUri(programPath)));
 	}
 
 	@Override

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/npm/NpmLaunchTab.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/debug/npm/NpmLaunchTab.java
@@ -39,6 +39,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.wildwebdeveloper.debug.AbstractDebugAdapterLaunchShortcut;
 import org.eclipse.wildwebdeveloper.debug.AbstractHTMLDebugDelegate;
 import org.eclipse.wildwebdeveloper.debug.LaunchConstants;
+import org.eclipse.wildwebdeveloper.util.FileUtils;
 
 public class NpmLaunchTab extends AbstractLaunchConfigurationTab {
 
@@ -168,7 +169,7 @@ public class NpmLaunchTab extends AbstractLaunchConfigurationTab {
 		configuration.setAttribute(LaunchConstants.PROGRAM, programPath);
 		configuration.setAttribute(AbstractHTMLDebugDelegate.ARGUMENTS, this.argumentsCombo.getText());
 		configuration.setAttribute(DebugPlugin.ATTR_WORKING_DIRECTORY, workingDirectory);
-		configuration.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(new File(programPath).toURI()));
+		configuration.setMappedResources(ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(FileUtils.toUri(programPath)));
 	}
 
 	@Override

--- a/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/util/FileUtils.java
+++ b/org.eclipse.wildwebdeveloper/src/org/eclipse/wildwebdeveloper/util/FileUtils.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.wildwebdeveloper.util;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.wildwebdeveloper.Activator;
+
+public class FileUtils {
+	private static final String FILE_SCHEME = "file"; //$NON-NLS-1$
+
+	public static File fromUri(String uri) {
+		// not using `new File(new URI(uri))` here which does not support Windows UNC paths
+		// and instead throws IllegalArgumentException("URI has an authority component")
+		return Paths.get(URI.create(uri)).toFile();
+	}
+
+	public static URI toUri(String filePath) {
+		return toUri(new File(filePath));
+	}
+
+	public static URI toUri(File file) {
+		// copied from org.eclipse.lsp4e.LSPEclipseUtils#toUri(File)
+
+		// URI scheme specified by language server protocol and LSP
+		try {
+			final var path = file.getAbsoluteFile().toURI().getPath();
+			if (path.startsWith("//")) { // UNC path like //localhost/c$/Windows/ //$NON-NLS-1$
+				// split: authority = "localhost", absPath = "/c$/Windows/"
+				final int slash = path.indexOf('/', 2);
+				final String authority = slash > 2 ? path.substring(2, slash) : path.substring(2);
+				final String absPath = slash > 2 ? path.substring(slash) : "/"; //$NON-NLS-1$
+				return new URI(FILE_SCHEME, authority, absPath, null);
+			}
+			return new URI(FILE_SCHEME, "", path, null); //$NON-NLS-1$
+		} catch (URISyntaxException ex) {
+			Activator.getDefault().getLog().log(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0, ex.getMessage(), ex));
+			return file.getAbsoluteFile().toURI();
+		}
+	}
+
+}


### PR DESCRIPTION
This partially addresses https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issues/162 To fully resolve the issue of supporting Windows UNC paths the inclusion of a new LSP4E release with this patch is required: https://github.com/eclipse-lsp4e/lsp4e/pull/1360

I tested it first only with the fix in LSP4E. While it fixed the outline view in JS/TS files, the ESLint server still failed to start with:
```py
java.lang.IllegalArgumentException: URI has an authority component  at java.base/java.io.File.<init>(File.java:425)
  at org.eclipse.wildwebdeveloper.eslint.ESLintClientImpl.configuration(ESLintClientImpl.java:57)
  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  at java.base/java.lang.reflect.Method.invoke(Method.java:580)
  at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$0(GenericEndpoint.java:65)
  at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.request(GenericEndpoint.java:128)
  at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleRequest(RemoteEndpoint.java:271)
  at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:201)
  at org.eclipse.lsp4e.LanguageServerWrapper.lambda$3(LanguageServerWrapper.java:415)
  at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:185)
  at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
  at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:114)
```