### PR TITLE
test: fix erratic error FileNotFoundException: http://.../catalog.dtd

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestXML.java
+++ b/org.eclipse.wildwebdeveloper.tests/src/org/eclipse/wildwebdeveloper/tests/TestXML.java
@@ -383,9 +383,11 @@ public class TestXML {
 			dialog.getShell().open();
 			dialog.getShell().close();
 
-			// Find system-catalog and parse it
+			// Find system.catalog in well known location from plugin
 			File systemCatalog = plugin.getStateLocation().append("system-catalog.xml").toFile();
-			Document systemCatalogDom = DocumentBuilderFactory.newDefaultInstance().newDocumentBuilder().parse(systemCatalog);
+			// Parse system-catalog to check it
+			Document systemCatalogDom = runWithLocalCatalogOnlyForTestXMLCatalog(
+					() -> DocumentBuilderFactory.newDefaultInstance().newDocumentBuilder().parse(systemCatalog));
 
 			// root element
 			Node catalogNode = systemCatalogDom.getLastChild();


### PR DESCRIPTION
Addresses erratic runtime exceptions because of catalog.dtd temporarily not being available online:
```py
	java.io.FileNotFoundException:
http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:2010)
	at ...
	at java.xml/javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:206)
	at org.eclipse.wildwebdeveloper.tests.TestXML.testXMLCatalogHttpsUriIncluded(TestXML.java:388)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```