### PR TITLE
Run codeql with Java 21

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,12 +80,12 @@ jobs:
 
 
     # CodeQL executes https://github.com/ferstl/depgraph-maven-plugin
-    - name: "Install: JDK 25 for Maven/Tycho ☕"
+    - name: "Install: JDK 21 for Maven/Tycho ☕"
       uses: actions/setup-java@v5  # https://github.com/actions/setup-java
       if: matrix.language == 'java'
       with:
         distribution: temurin
-        java-version: 25
+        java-version: 21
 
 
     # https://docs.github.com/en/code-security/code-scanning


### PR DESCRIPTION
Effort to make false positive reports like
https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/security/code-scanning/46 gone as to fix this one one has to move to next Java LTS (25) for https://openjdk.org/jeps/456 .