### PR TITLE
Generate license summary even without a GitLab token

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -111,9 +111,12 @@ jobs:
         npmArgs=" --no-bin-links --ignore-scripts"
         dashArgs="-excludeSources local -summary $savePWD/target/dash/npm-review-summary"
         exitStatus=0
-        if [ ${{ env.request-review }} ]; then 
-          # Add "-project <Project Name> -token <Token>" here when a review is required
-          dashArgs="$dashArgs -review -project $projectId -token $gitlabAPIToken" 
+        if [ -n "$gitlabAPIToken" ]; then
+          # A GitLab token is available (e.g. on branches/PRs that can access
+          # repository secrets), so request a review automatically. Dependabot
+          # and fork pull requests don't get the secret; in that case we skip
+          # the review request and still produce the summary of unvetted deps.
+          dashArgs="$dashArgs -review -project $projectId -token $gitlabAPIToken"
         fi
         #
         # Check NPM dependency licenses in main WildWebDeveloper project 


### PR DESCRIPTION
Dependabot and fork pull requests don't have access to the GITLAB_API_TOKEN secret. Passing an empty token to dash-licenses made it consume the package-lock.json path as the token value, producing a usage error and no review summary.

Only pass -review/-project/-token when a token is present. Without a token the tool still runs and writes the summary of unvetted dependencies, which the reporting step then comments on the PR and fails the run for.