### PR TITLE
Improve the setup and reduce warnings

### DIFF
--- a/org.eclipse.wildwebdeveloper.tests/testProjects/astro-app/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.wildwebdeveloper.tests/testProjects/astro-app/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.wildwebdeveloper/plugin.xml
+++ b/org.eclipse.wildwebdeveloper/plugin.xml
@@ -1101,6 +1101,7 @@
       <keyword label="%preferenceKeywords.sass" id="org.eclipse.wildwebdeveloper.sass" />
       <keyword label="%preferenceKeywords.scss" id="org.eclipse.wildwebdeveloper.scss" />
       <keyword label="%preferenceKeywords.html" id="org.eclipse.wildwebdeveloper.html" />
+      <keyword label="%preferenceKeywords.markdown" id="org.eclipse.wildwebdeveloper.markdown" />
    </extension>
 
 </plugin>

--- a/setup/WWD.setup
+++ b/setup/WWD.setup
@@ -212,11 +212,15 @@
           locateNestedProjects="true"/>
       <repositoryList>
         <repository
-            url="https://download.eclipse.org/releases/${eclipse.target.platform}"/>
-        <repository
             url="http://download.eclipse.org/cbi/updates/license"/>
         <repository
-            url="https://download.eclipse.org/lsp4e/releases/latest"/>
+            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
+        <repository
+            url="https://download.eclipse.org/releases/${eclipse.target.platform}"/>
+        <repository
+            url="https://download.eclipse.org/lsp4e/snapshots"/>
+        <repository
+            url="https://download.eclipse.org/tm4e/snapshots"/>
       </repositoryList>
     </targlet>
   </setupTask>


### PR DESCRIPTION
- Use repositories with more recent content for the targlets so that one can work at development time with newer dependencies as soon as they are available to catch problems earlier.
- Add project encoding for the astro example.
- Eliminate warning about missing org.eclipse.wildwebdeveloper.markdown keyword id.