### PR TITLE
Improve the setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,13 @@ Latest builds, for testing, can usually be found at `https://download.eclipse.or
 
 ### Prerequisites
 
-Java 21 and Maven 3.9.6 (only if you want to build from the command-line), or newer.
+Java 21 and Maven 3.9.12 (only if you want to build from the command-line), or newer.
+
+### 🧙 Setting up the Development Environment Automatically
+
+You can set up a pre-configured IDE for contribution to Eclipse Wild Web Developer using the following link:
+
+[![Create Eclipse Development Environment for the Eclipse SDK](https://download.eclipse.org/oomph/www/setups/svg/Wild_Web_Developer.svg)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-wildwebdeveloper/wildwebdeveloper/master/setup/WWDConfiguration.setup&show=true "Click to open Eclipse-Installer Auto Launch or drag onto your running installer's title area")
 
 ### ⌨️ Setting up the Development Environment manually
 

--- a/setup/WWD.setup
+++ b/setup/WWD.setup
@@ -377,6 +377,35 @@
 
     </content>
   </setupTask>
+  <setupTask
+      xsi:type="setup:CompoundTask"
+      filter="(osgi.os=win32)">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        type="FOLDER"
+        name="node.location"
+        label="Node.js Installation Location"
+        link="https://nodejs.org/en/download">
+      <description>The location of the Node.js installation on this device.</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="git.location"
+        defaultValue="C:\Program Files\Git"
+        label="Git Installation Location"
+        link="https://git-scm.com/install/windows">
+      <description>The location of Git installation on this device.</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        targetURL="${installation.location|uri}/${installation.relativeProductFolder}/wwd2.sh">
+      <content>
+        #!/bin/bash
+        export PATH=&quot;${node.location|cygpath}/:${git.location|cygpath}/mingw64/bin:${git.location|cygpath}/usr/bin:$PATH&quot;
+        ./eclipse.exe $*
+      </content>
+    </setupTask>
+  </setupTask>
   <stream name="master"
       label="Master">
     <setupTask


### PR DESCRIPTION
- Add tasks for windows to create a wwwd.sh for launching the IDE with an augment PATH that includes Node.js and Git which is needed by the Maven task in order to build the project's content.
- Add a badge link to the setup configuration the CONTRIBUTING.md.