### PR TITLE
Improve setup

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/setup/WWD.setup
+++ b/setup/WWD.setup
@@ -379,7 +379,8 @@
   </setupTask>
   <setupTask
       xsi:type="setup:CompoundTask"
-      filter="(osgi.os=win32)">
+      filter="(osgi.os=win32)"
+      name="Create wwwd.sh for WIndows">
     <setupTask
         xsi:type="setup:VariableTask"
         type="FOLDER"
@@ -398,7 +399,7 @@
     </setupTask>
     <setupTask
         xsi:type="setup:ResourceCreationTask"
-        targetURL="${installation.location|uri}/${installation.relativeProductFolder}/wwd2.sh">
+        targetURL="${installation.location|uri}/${installation.relativeProductFolder}/wwd.sh">
       <content>
         #!/bin/bash
         export PATH=&quot;${node.location|cygpath}/:${git.location|cygpath}/mingw64/bin:${git.location|cygpath}/usr/bin:$PATH&quot;


### PR DESCRIPTION
- Set project encoding for org.eclipse.wildwebdeveloper.embedder.node.macos.aarch64.