### PR TITLE
Use org.eclipse.tm4e.ui.samples instead of org.eclipse.tm4e.ui.snippets

### DIFF
--- a/org.eclipse.wildwebdeveloper.xml/plugin.xml
+++ b/org.eclipse.wildwebdeveloper.xml/plugin.xml
@@ -139,12 +139,12 @@
    </extension>
 
    <extension
-         point="org.eclipse.tm4e.ui.snippets">
-      <snippet
+         point="org.eclipse.tm4e.ui.samples">
+      <sample
             name="XML Sample"
             path="snippets/xml/sample.xml"
             scopeName="text.xml">
-      </snippet>
+      </sample>
    </extension>
    <extension
          point="org.eclipse.ui.genericeditor.icons">


### PR DESCRIPTION
- The former is deprecated in favor of the latter.