### PR TITLE
Remove bin.excludes from /org.eclipse.wildwebdeveloper/build.properties

### DIFF
--- a/org.eclipse.wildwebdeveloper/build.properties
+++ b/org.eclipse.wildwebdeveloper/build.properties
@@ -11,5 +11,3 @@ bin.includes = META-INF/,\
                schema/,\
                js-debug/,\
                plugin.properties
-# See https://github.com/redhat-developer/yaml-language-server/issues/253
-bin.excludes = node_modules/yaml-language-server/out/server/node_modules/


### PR DESCRIPTION
- The exclusion of node_modules/yaml-language-server/out/server/node_modules/ was added as a workaround for
https://github.com/redhat-developer/yaml-language-server/issues/253 but that issue was fixed and now the resource doesn't exist causing a warning.