### PR TITLE
Use Files.isDirectory/isWritable/isExecutable to determine permissions

### DIFF
--- a/org.eclipse.wildwebdeveloper.embedder.node/src/org/eclipse/wildwebdeveloper/embedder/node/NodeJSManager.java
+++ b/org.eclipse.wildwebdeveloper.embedder.node/src/org/eclipse/wildwebdeveloper/embedder/node/NodeJSManager.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -245,8 +246,8 @@ public class NodeJSManager {
         if (directory == null) {
             return false;
         }
-        if (directory.exists() && directory.isDirectory()
-                && directory.canWrite() && directory.canExecute()) {
+        java.nio.file.Path path = directory.toPath();
+        if (Files.isDirectory(path) && Files.isWritable(path) && Files.isExecutable(path)) {
             return true;
         }
         return probeDirectoryForInstallation(directory.getParentFile());


### PR DESCRIPTION
- Fix NodeJSManager.probeDirectoryForInstallation(File) to use java.nio.Files operations which is more reliable.
- File.canWrite is not reliable on Windows with its complex access-list-based permissions. Also File.canExecute is not meaningful for a folder and is intended to indicate if a file (not a directory) is executable.

https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issues/2106