### PR TITLE
Use `agent any` for promotion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,9 +145,7 @@ BRANCH_NAME=${env.BRANCH_NAME}
       when {
         environment name: 'PROMOTE', value: 'true'
       }
-      agent {
-        label 'centos-latest'
-      }
+      agent any
       tools {
         maven 'apache-maven-latest'
         jdk 'temurin-jdk21-latest'


### PR DESCRIPTION
- Both ubuntu-latest and centos-latest often fail to start and I've done a replay using `agent any` that successfully published a nightly build.