### PR TITLE
Use `beforeAgent true` for the when condition of Deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,6 +143,7 @@ BRANCH_NAME=${env.BRANCH_NAME}
 
     stage('Deploy') {
       when {
+        beforeAgent true
         environment name: 'PROMOTE', value: 'true'
       }
       agent any


### PR DESCRIPTION
- The value of the condition does not depend on the agent and for PR builds we never deploy, so it makes no sense to wait for an agent to evaluate a condition that will be false always for a PR.